### PR TITLE
flush generator output

### DIFF
--- a/brewblox_tools/deploy_docker.py
+++ b/brewblox_tools/deploy_docker.py
@@ -43,7 +43,7 @@ def build(client, args):
             output = next(generator).rstrip()
             json_output = json.loads(output)
             if 'stream' in json_output:
-                print(json_output['stream'].rstrip())
+                print(json_output['stream'].rstrip(), flush=True)
         except StopIteration:
             print('Docker image build complete.')
             break
@@ -66,7 +66,7 @@ def push(client, args):
             output = line.rstrip()
             json_output = json.loads(output)
             msg = ' '.join([str(v) for v in json_output.values()])
-            print(msg)
+            print(msg, flush=True)
 
 
 def main(sys_args: list=None):


### PR DESCRIPTION
Occasionally, the deployment script in Travis will be very slow in picking up bbt-deploy-docker output.

If no output is received in 10 minutes, it will cancel the build. This was originally resolved by using `python3 -u`, but we can't pass arguments to python itself when using entry_points scripts.